### PR TITLE
compile packages/react to esm too

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@usebasejump/react",
   "version": "0.0.5",
-  "main": "dist/index.js",
+  "main": "dist/index.mjs",
   "module": "dist/index.mjs",
+  "type":"module",
   "types": "dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/react/tsup.config.ts
+++ b/packages/react/tsup.config.ts
@@ -4,7 +4,7 @@ export const tsup: Options = {
     dts: true,
     entryPoints: ['src/index.tsx'],
     external: ['react', /^@usebasejump\//],
-    format: ['cjs'],
+    format: ['esm', 'cjs'],
     legacyOutput: false,
     sourcemap: true,
     splitting: false,


### PR DESCRIPTION
This solves the issue with the missing esm build causing this: https://github.com/usebasejump/basejump/issues/67