### PR TITLE
Fix typo, and fix type error

### DIFF
--- a/apps/basejump-docs/src/pages/docs/accounts.mdx
+++ b/apps/basejump-docs/src/pages/docs/accounts.mdx
@@ -16,7 +16,7 @@ If you opt into both personal and team accounts, your app will operate similar t
 
 ## The account model
 
-Not all endpoints return all account data - particularly around billing as that can require additinoal calls to third parties to verify. Below is a breakdown of fields you can expect to get back when interacting with accounts.
+Not all endpoints return all account data - particularly around billing as that can require additional calls to third parties to verify. Below is a breakdown of fields you can expect to get back when interacting with accounts.
 
 ### Properties
 

--- a/apps/nextjs-starter/src/app/dashboard/(personalAccount)/settings/layout.tsx
+++ b/apps/nextjs-starter/src/app/dashboard/(personalAccount)/settings/layout.tsx
@@ -2,7 +2,7 @@ import SettingsNavigation from "@/components/dashboard/SettingsNavigation";
 import DashboardTitle from "@/components/dashboard/DashboardTitle";
 import {Separator} from "@/components/ui/separator.tsx";
 
-export default function PersonalAccountSettingsPage({children}) {
+export default function PersonalAccountSettingsPage({children}: {children: React.ReactNode}) {
     const items = [
         { name: "Profile", href: "/dashboard/settings" },
         { name: "Teams", href: "/dashboard/settings/teams" },


### PR DESCRIPTION
change 'additinoal' to 'additional' in docs, account page.

Fix type error that was preventing Vercel deployment of starter app.

./src/app/dashboard/(personalAccount)/settings/layout.tsx

On line 5:54: `export default function PersonalAccountSettingsPage({children}) {`

I was getting the error: `Type error: Binding element 'children' implicitly has an 'any' type.` when deploying to Vercel. 

I changed to `export default function PersonalAccountSettingsPage({children}: {children: React.ReactNode}) {`

This resolved the error and Vercel build ran cleanly.